### PR TITLE
CP-52225: Misc improvements

### DIFF
--- a/oxenstored/connection.ml
+++ b/oxenstored/connection.ml
@@ -317,7 +317,7 @@ let get_children_watches con path =
   let path = path ^ "/" in
   List.concat
     (Hashtbl.fold
-       (fun p w l -> if String.startswith path p then w :: l else l)
+       (fun p w l -> if String.starts_with ~prefix:path p then w :: l else l)
        con.watches []
     )
 

--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -20,7 +20,9 @@ module Xeneventchn = Eventchn
 let debug fmt = Logging.debug "connections" fmt
 
 type t = {
-    anonymous: (Unix.file_descr, Connection.t) Hashtbl.t
+    anonymous: (Unix.file_descr, Connection.t * int) Hashtbl.t
+        (* (fd -> Connection.t, index) where index maps to the poll_status array *)
+  ; mutable poll_status: (Unix.file_descr * Poll.event) array
   ; domains: (int, Connection.t) Hashtbl.t
   ; ports: (Xeneventchn.t, Connection.t) Hashtbl.t
   ; mutable watches: Connection.watch list Trie.t
@@ -30,6 +32,7 @@ type t = {
 let create () =
   {
     anonymous= Hashtbl.create 37
+  ; poll_status= [||]
   ; domains= Hashtbl.create 37
   ; ports= Hashtbl.create 37
   ; watches= Trie.create ()
@@ -43,11 +46,17 @@ let get_capacity () =
   ; maxwatchevents= !Define.maxwatchevents
   }
 
+let default_poll_status () = (Unix.stdin, Poll.init_event ())
+
+let spec_poll_status () = Poll.{read= true; write= false; except= false}
+
 let add_anonymous cons fd =
   let capacity = get_capacity () in
   let xbcon = Xenbus.Xb.open_fd fd ~capacity in
   let con = Connection.create xbcon None in
-  Hashtbl.add cons.anonymous (Xenbus.Xb.get_fd xbcon) con
+  Hashtbl.replace cons.anonymous (Xenbus.Xb.get_fd xbcon)
+    (con, Array.length cons.poll_status) ;
+  cons.poll_status <- Array.append cons.poll_status [|default_poll_status ()|]
 
 let add_domain cons dom =
   let capacity = get_capacity () in
@@ -57,23 +66,34 @@ let add_domain cons dom =
     )
   in
   let con = Connection.create xbcon (Some dom) in
-  Hashtbl.add cons.domains (Domain.get_id dom) con ;
-  Hashtbl.add cons.ports (Domain.get_local_port dom) con
+  Hashtbl.replace cons.domains (Domain.get_id dom) con ;
+  Hashtbl.replace cons.ports (Domain.get_local_port dom) con
 
-let select ?(only_if = fun _ -> true) cons =
-  Hashtbl.fold
-    (fun _ con (ins, outs) ->
-      if only_if con then
-        let fd = Connection.get_fd con in
-        let in_fds = if Connection.can_input con then fd :: ins else ins in
-        let out_fds = if Connection.has_output con then fd :: outs else outs in
-        (in_fds, out_fds)
-      else
-        (ins, outs)
+let refresh_poll_status ?(only_if = fun _ -> true) cons spec_fds =
+  (* special fds are always read=true, but get overwritten by select_stubs, so we
+     need to reset the event we are polling for *)
+  List.iteri
+    (fun index fd -> cons.poll_status.(index) <- (fd, spec_poll_status ()))
+    spec_fds ;
+  Hashtbl.iter
+    (fun _ (con, index) ->
+      let only = only_if con in
+      let fd = Connection.get_fd con in
+      let open Poll in
+      let event =
+        {
+          read= only && Connection.can_input con
+        ; write= only && Connection.has_output con
+        ; except= false
+        }
+      in
+      cons.poll_status.(index) <- (fd, event)
     )
-    cons.anonymous ([], [])
+    cons.anonymous
 
-let find cons = Hashtbl.find cons.anonymous
+let find cons fd =
+  let c, _ = Hashtbl.find cons.anonymous fd in
+  c
 
 let find_domain cons = Hashtbl.find cons.domains
 
@@ -94,11 +114,35 @@ let del_watches cons con =
     |> Connection.Watch.Set.filter @@ fun w -> Connection.get_con w != con
     )
 
-let del_anonymous cons con =
+let del_anonymous cons con spec_fds =
   try
     Hashtbl.remove cons.anonymous (Connection.get_fd con) ;
-    del_watches cons con ;
-    Connection.close con
+    (* Reallocate the poll_status array, update indices pointing to it *)
+    cons.poll_status <-
+      Array.make
+        (Hashtbl.length cons.anonymous + List.length spec_fds)
+        (default_poll_status ()) ;
+
+    (* Keep the special fds at the beginning *)
+    let i =
+      List.fold_left
+        (fun index fd ->
+          cons.poll_status.(index) <- (fd, spec_poll_status ()) ;
+          index + 1
+        )
+        0 spec_fds
+    in
+
+    let _ =
+      Hashtbl.fold
+        (fun key (con, _) i ->
+          Hashtbl.replace cons.anonymous key (con, i) ;
+          i + 1
+        )
+        cons.anonymous i
+    in
+
+    del_watches cons con ; Connection.close con
   with exn -> debug "del anonymous %s" (Printexc.to_string exn)
 
 let del_domain cons id =
@@ -116,7 +160,8 @@ let del_domain cons id =
 
 let iter_domains cons fct = Hashtbl.iter (fun _ c -> fct c) cons.domains
 
-let iter_anonymous cons fct = Hashtbl.iter (fun _ c -> fct c) cons.anonymous
+let iter_anonymous cons fct =
+  Hashtbl.iter (fun _ (c, _) -> fct c) cons.anonymous
 
 let iter cons fct = iter_domains cons fct ; iter_anonymous cons fct
 
@@ -227,7 +272,7 @@ let stats cons =
 let debug cons =
   let anonymous =
     Hashtbl.fold
-      (fun _ con accu -> Connection.debug con :: accu)
+      (fun _ (con, _) accu -> Connection.debug con :: accu)
       cons.anonymous []
   in
   let domains =
@@ -258,6 +303,7 @@ let debug_watchevents cons con =
 
 let filter ~f cons =
   let fold _ v acc = if f v then v :: acc else acc in
-  [] |> Hashtbl.fold fold cons.anonymous |> Hashtbl.fold fold cons.domains
+  let fold_a _ (v, _) acc = if f v then v :: acc else acc in
+  [] |> Hashtbl.fold fold_a cons.anonymous |> Hashtbl.fold fold cons.domains
 
 let prevents_quit cons = filter ~f:Connection.prevents_live_update cons

--- a/oxenstored/logging.ml
+++ b/oxenstored/logging.ml
@@ -25,7 +25,7 @@ let log_destination_of_string s =
   let prefix = "syslog:" in
   let len_prefix = String.length prefix in
   let len = String.length s in
-  if String.startswith prefix s then
+  if String.starts_with ~prefix s then
     Syslog
       (Syslog.facility_of_string (String.sub s len_prefix (len - len_prefix)))
   else
@@ -435,7 +435,7 @@ let live_update () =
 let xb_answer ~tid ~con ~ty data =
   let print, level =
     match ty with
-    | Xenbus.Xb.Op.Error when String.startswith "ENOENT" data ->
+    | Xenbus.Xb.Op.Error when String.starts_with ~prefix:"ENOENT" data ->
         (!access_log_read_ops, Warn)
     | Xenbus.Xb.Op.Error ->
         (true, Warn)

--- a/oxenstored/poll.ml
+++ b/oxenstored/poll.ml
@@ -17,6 +17,8 @@
    readfds, writefds, exceptfds concept as in select. *)
 type event = {mutable read: bool; mutable write: bool; mutable except: bool}
 
+let init_event () = {read= false; write= false; except= false}
+
 external select_on_poll : (Unix.file_descr * event) array -> int -> int
   = "stub_select_on_poll"
 
@@ -31,33 +33,8 @@ let get_sys_fs_nr_open () =
     close_in_noerr ch ; v
   with _ -> 1024 * 1024
 
-let init_event () = {read= false; write= false; except= false}
-
-let poll_select in_fds out_fds exc_fds timeout =
-  let h = Hashtbl.create 57 in
-  let add_event event_set fd =
-    let e =
-      try Hashtbl.find h fd
-      with Not_found ->
-        let e = init_event () in
-        Hashtbl.add h fd e ; e
-    in
-    event_set e
-  in
-  List.iter (add_event (fun x -> x.read <- true)) in_fds ;
-  List.iter (add_event (fun x -> x.write <- true)) out_fds ;
-  List.iter (add_event (fun x -> x.except <- true)) exc_fds ;
-  (* Unix.stdin and init_event are dummy input as stubs, which will
-            always be overwritten later on. *)
-  let a = Array.make (Hashtbl.length h) (Unix.stdin, init_event ()) in
-  let i = ref (-1) in
-  Hashtbl.iter
-    (fun fd event ->
-      incr i ;
-      Array.set a !i (fd, event)
-    )
-    h ;
-  let n = select_on_poll a (int_of_float (timeout *. 1000.)) in
+let poll_select fdarr timeout =
+  let n = select_on_poll fdarr (int_of_float (timeout *. 1000.)) in
   let r = ([], [], []) in
   if n = 0 then
     r
@@ -69,6 +46,6 @@ let poll_select in_fds out_fds exc_fds timeout =
         , if event.except then fd :: x else x
         )
       )
-      a r
+      fdarr r
 
 let () = set_fd_limit (get_sys_fs_nr_open ())

--- a/oxenstored/poll.mli
+++ b/oxenstored/poll.mli
@@ -12,10 +12,11 @@
  * GNU Lesser General Public License for more details.
  *)
 
+type event = {mutable read: bool; mutable write: bool; mutable except: bool}
+
+val init_event : unit -> event
+
 val poll_select :
-     Unix.file_descr list
-  -> Unix.file_descr list
-  -> Unix.file_descr list
+     (Unix.file_descr * event) array
   -> float
   -> Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
-(** Same interface and semantics as [Unix.select], implemented using poll(3). *)

--- a/oxenstored/stdext.ml
+++ b/oxenstored/stdext.ml
@@ -82,18 +82,6 @@ module String = struct
       let a = String.sub s 0 i
       and b = String.sub s (i + 1) (String.length s - i - 1) in
       a :: split ~limit:nlimit c b
-
-  let fold_left f accu string =
-    let accu = ref accu in
-    for i = 0 to length string - 1 do
-      accu := f !accu string.[i]
-    done ;
-    !accu
-
-  (** True if string 'x' starts with prefix 'prefix' *)
-  let startswith prefix x =
-    let x_l = String.length x and prefix_l = String.length prefix in
-    prefix_l <= x_l && String.sub x 0 prefix_l = prefix
 end
 
 module Unixext = struct

--- a/oxenstored/store.ml
+++ b/oxenstored/store.ml
@@ -142,9 +142,7 @@ module Path = struct
     || c = '-'
     || c = '@'
 
-  let name_is_valid name =
-    name <> ""
-    && String.fold_left (fun accu c -> accu && char_is_valid c) true name
+  let name_is_valid name = name <> "" && String.for_all char_is_valid name
 
   let is_valid path = List.for_all name_is_valid path
 

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -29,20 +29,20 @@ let debug fmt = Logging.debug "xenstored" fmt
 let info fmt = Logging.info "xenstored" fmt
 
 (*------------ event klass processors --------------*)
-let process_connection_fds store cons domains rset wset =
+let process_connection_fds store cons domains rset wset spec_fds =
   let try_fct fct c =
     try fct store cons domains c with
     | Unix.Unix_error (err, "write", _) ->
-        Connections.del_anonymous cons c ;
+        Connections.del_anonymous cons c spec_fds ;
         error "closing socket connection: write error: %s"
           (Unix.error_message err)
     | Unix.Unix_error (err, "read", _) ->
-        Connections.del_anonymous cons c ;
+        Connections.del_anonymous cons c spec_fds ;
         if err <> Unix.ECONNRESET then
           error "closing socket connection: read error: %s"
             (Unix.error_message err)
     | Xenbus.Xb.End_of_file ->
-        Connections.del_anonymous cons c ;
+        Connections.del_anonymous cons c spec_fds ;
         debug "closing socket connection"
   in
   let process_fdset_with fds fct =
@@ -528,6 +528,13 @@ let () =
     (match rw_sock with None -> [] | Some x -> [x])
     @ if cf.domain_init then [Event.fd eventchn] else []
   in
+  (* Always positioned at the start of cons.poll_status, maintained during
+     reallocations *)
+  cons.poll_status <-
+    Array.append cons.poll_status
+      (Array.of_list
+         (List.map (fun fd -> (fd, Connections.spec_poll_status ())) spec_fds)
+      ) ;
 
   let process_special_fds rset =
     let accept_connection fd =
@@ -681,9 +688,9 @@ let () =
       in
       if peaceful_mw <> [] then 0. else until_next_activity
     in
-    let inset, outset = Connections.select ~only_if:is_peaceful cons in
+    Connections.refresh_poll_status ~only_if:is_peaceful cons spec_fds ;
     let rset, wset, _ =
-      try Poll.poll_select (spec_fds @ inset) outset [] timeout
+      try Poll.poll_select cons.poll_status timeout
       with Unix.Unix_error (Unix.EINTR, _, _) -> ([], [], [])
     in
     let sfds, cfds = List.partition (fun fd -> List.mem fd spec_fds) rset in
@@ -691,7 +698,7 @@ let () =
       process_special_fds sfds ;
 
     if cfds <> [] || wset <> [] then
-      process_connection_fds store cons domains cfds wset ;
+      process_connection_fds store cons domains cfds wset spec_fds ;
     ( if timeout <> 0. then
         let now = Unix.gettimeofday () in
         if now > !period_start +. period_ops_interval then (


### PR DESCRIPTION
CP-52225 - poll: Reduce unnecessary allocations

No need to maintain interface compatibility with select anymore,
allocate an array of connection's poll status and modify that instead of
allocating an array, three lists, and a hash table on each iteration of
the main listening loop.

---

poll_select optimizations remove 10% of samples from the entire xenstore loop during a stress-test at creating 512 VMs:

![xenstore-old-poll](https://github.com/user-attachments/assets/2e133675-6f7e-432c-9c64-7041a72fd961)

![xenstore-new-poll](https://github.com/user-attachments/assets/60d42b6e-3584-46d2-8f8c-e1bb992833c6)
