### PR TITLE
logging: make xenstored-access less cryptic

### DIFF
--- a/oxenstored/connection.ml
+++ b/oxenstored/connection.ml
@@ -185,9 +185,9 @@ let anon_id_next = ref 1
 let get_domstr con =
   match con.dom with
   | None ->
-      "A" ^ string_of_int con.anonid
+      Printf.sprintf "DOM0 (ANON CONN #%d)" con.anonid
   | Some dom ->
-      "D" ^ string_of_int (Domain.get_id dom)
+      Printf.sprintf "DOM%d" (Domain.get_id dom)
 
 let make_perm dom =
   let domid = match dom with None -> 0 | Some d -> Domain.get_id d in


### PR DESCRIPTION
Feedback from the support team made it clear that it's better to be consistent across different logs, and xenstored-access.log's "D4" and "A7" aren't clear at all. Switch instead to "DOMID4" and "DOM0 (ANON CONN #7)" respectively.

These strings were only used in logging, so no functional changes.