### PR TITLE
CP-44717: Significant optimizations

### DIFF
--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -48,7 +48,8 @@ let get_capacity () =
 
 let default_poll_status () = (Unix.stdin, Poll.init_event ())
 
-let spec_poll_status () = Poll.{read= true; write= false; except= false}
+let spec_poll_status () =
+  Poll.{read= true; write= false; can_read= false; can_write= false}
 
 let add_anonymous cons fd =
   let capacity = get_capacity () in

--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -72,27 +72,6 @@ let add_domain cons dom =
   Hashtbl.replace cons.domains (Domain.get_id dom) con ;
   Hashtbl.replace cons.ports (Domain.get_local_port dom) con
 
-let refresh_poll_status cons spec_fds =
-  (* special fds are always read=true, but get overwritten by select_stubs, so we
-     need to reset the event we are polling for *)
-  List.iteri
-    (fun index fd -> cons.poll_status.(index) <- (fd, spec_poll_status ()))
-    spec_fds ;
-  Hashtbl.iter
-    (fun _ (con, index) ->
-      let fd = Connection.get_fd con in
-      let open Poll in
-      let event =
-        {
-          read= Connection.can_input con
-        ; write= Connection.has_output con
-        ; except= false
-        }
-      in
-      cons.poll_status.(index) <- (fd, event)
-    )
-    cons.anonymous
-
 let find cons fd =
   let c, _ = Hashtbl.find cons.anonymous fd in
   c

--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -106,13 +106,15 @@ let del_watches_of_con con watches =
   | ws ->
       Some ws
 
-let del_watches cons con =
-  Connection.del_watches con ;
-  cons.watches <- Trie.map (del_watches_of_con con) cons.watches ;
-  cons.has_pending_watchevents <-
-    (cons.has_pending_watchevents
-    |> Connection.Watch.Set.filter @@ fun w -> Connection.get_con w != con
-    )
+let del_watches cons (con : Connection.t) =
+  if con.nb_watches > 0 then (
+    Connection.del_watches con ;
+    cons.watches <- Trie.map (del_watches_of_con con) cons.watches ;
+    cons.has_pending_watchevents <-
+      (cons.has_pending_watchevents
+      |> Connection.Watch.Set.filter @@ fun w -> Connection.get_con w != con
+      )
+  )
 
 let del_anonymous cons con spec_fds =
   try

--- a/oxenstored/poll.mli
+++ b/oxenstored/poll.mli
@@ -12,11 +12,16 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type event = {mutable read: bool; mutable write: bool; mutable except: bool}
+type event = {
+    mutable read: bool
+  ; mutable write: bool
+  ; mutable can_read: bool
+  ; mutable can_write: bool
+}
 
 val init_event : unit -> event
 
 val poll_select :
      (Unix.file_descr * event) array
   -> float
-  -> Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
+  -> Unix.file_descr list * Unix.file_descr list

--- a/oxenstored/select_stubs.c
+++ b/oxenstored/select_stubs.c
@@ -44,9 +44,6 @@ stub_select_on_poll (value fd_events, value timeo)
                           Bool_val (Field (events, 0)) ? POLLIN : 0;
                   c_fds[i].events |=
                           Bool_val (Field (events, 1)) ? POLLOUT : 0;
-                  c_fds[i].events |=
-                          Bool_val (Field (events, 2)) ? POLLPRI : 0;
-
           };
 
         caml_enter_blocking_section ();
@@ -66,19 +63,16 @@ stub_select_on_poll (value fd_events, value timeo)
 
                             if (c_fds[i].revents & POLLNVAL)
                                     unix_error (EBADF, "select", Nothing);
-                            Field (events, 0) =
+                            Field (events, 2) =
                                     Val_bool (c_fds[i].events & POLLIN
                                               && c_fds[i].revents & (POLLIN |
                                                                      POLLHUP |
                                                                      POLLERR));
-                            Field (events, 1) =
+                            Field (events, 3) =
                                     Val_bool (c_fds[i].events & POLLOUT
                                               && c_fds[i].revents & (POLLOUT |
                                                                      POLLHUP |
                                                                      POLLERR));
-                            Field (events, 2) =
-                                    Val_bool (c_fds[i].revents & POLLPRI);
-
                     }
 
           }

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -689,9 +689,9 @@ let () =
       if peaceful_mw <> [] then 0. else until_next_activity
     in
     Connections.refresh_poll_status cons spec_fds ;
-    let rset, wset, _ =
+    let rset, wset =
       try Poll.poll_select cons.poll_status timeout
-      with Unix.Unix_error (Unix.EINTR, _, _) -> ([], [], [])
+      with Unix.Unix_error (Unix.EINTR, _, _) -> ([], [])
     in
     let sfds, cfds = List.partition (fun fd -> List.mem fd spec_fds) rset in
     if sfds <> [] then

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -688,7 +688,6 @@ let () =
       in
       if peaceful_mw <> [] then 0. else until_next_activity
     in
-    Connections.refresh_poll_status cons spec_fds ;
     let rset, wset =
       try Poll.poll_select cons.poll_status timeout
       with Unix.Unix_error (Unix.EINTR, _, _) -> ([], [])


### PR DESCRIPTION
Please review carefully - this is very sensitive code. I've done my best to verify it works correctly manually (correct fds are polled for correct events), this also passed Ring3 BST+BVT (211978), and was stress tested with my Windows 11 VM creation simulation scripts.

===

* The first commit greatly reduces overhead when handling large numbers of watches (not captured in the graph below)
* 'Minor hotspot optimizations' commit can be dropped given that `refresh_poll_connections` is removed entirely later on, but I've kept it since it's a worthwhile and safe optimization on its own if larger refactoring needs to be reverted later.
* Further commits are all a part of refactoring of `refresh_poll_connections` that moves from updating `poll_status` for every connection before every call to `poll` to handling these per-connection in an event-based update system.

These optimizations bring Oxenstored closer to Cxenstored's performance (and at times, it performs even better). Oxenstored now scales better than it used to with the number of watches, connections, simultaneous calls. 

Note that the comparisons are with forked Oxenstored before this PR, not with the upstream Oxenstored (which is even worse). The falloff at the end of the graphs is because once the number of simultaneously done calls is reduced as threads finish their work, each finishes quicker.

![optimizations](https://github.com/user-attachments/assets/f26e5403-26ea-4cdd-97e8-7aa1fbcb77c1)

Thus, improvements are roughly around:
- 22% for 1 thread
- 30% for 2 threads
- 34% for 4 threads
- 45% for 6 threads