### PR TITLE
Revert "xenstored: drop direct systemd dependency" AKA Running in circles

### DIFF
--- a/oxenstored/dune
+++ b/oxenstored/dune
@@ -6,7 +6,7 @@
  (flags
   (:standard -w -52))
  (libraries unix xenbus xen-evtchn xen-evtchn-unix-minimal
-            xengnt xenmmap syslog xsd_glue
+            xengnt xenmmap syslog xsd_glue systemd
             dune-site dune-site.plugins))
 
 (generate_sites_module

--- a/oxenstored/systemd/dune
+++ b/oxenstored/systemd/dune
@@ -1,0 +1,8 @@
+(library
+ (foreign_stubs (language c) (names systemd_stubs)
+                (include_dirs include)
+                (flags :standard -DHAVE_SYSTEMD))
+ (modules systemd)
+ (name systemd)
+ (wrapped false)
+ (no_dynlink))

--- a/oxenstored/systemd/include/xen-sd-notify.h
+++ b/oxenstored/systemd/include/xen-sd-notify.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: MIT-0 */
+
+/*
+ * Implement the systemd notify protocol without external dependencies.
+ * Supports both readiness notification on startup and on reloading,
+ * according to the protocol defined at:
+ * https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
+ * This protocol is guaranteed to be stable as per:
+ * https://systemd.io/PORTABILITY_AND_STABILITY/
+ *
+ * Differences from the upstream copy:
+ * - Rename/rework as a drop-in replacement for systemd/sd-daemon.h
+ * - Only take the subset Xen cares about
+ * - Respect -Wdeclaration-after-statement
+ */
+
+#ifndef XEN_SD_NOTIFY
+#define XEN_SD_NOTIFY
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static inline void xen_sd_closep(int *fd) {
+  if (!fd || *fd < 0)
+    return;
+
+  close(*fd);
+  *fd = -1;
+}
+
+static inline int xen_sd_notify(const char *message) {
+  union sockaddr_union {
+    struct sockaddr sa;
+    struct sockaddr_un sun;
+  } socket_addr = {
+    .sun.sun_family = AF_UNIX,
+  };
+  size_t path_length, message_length;
+  ssize_t written;
+  const char *socket_path;
+  int __attribute__((cleanup(xen_sd_closep))) fd = -1;
+
+  /* Verify the argument first */
+  if (!message)
+    return -EINVAL;
+
+  message_length = strlen(message);
+  if (message_length == 0)
+    return -EINVAL;
+
+  /* If the variable is not set, the protocol is a noop */
+  socket_path = getenv("NOTIFY_SOCKET");
+  if (!socket_path)
+    return 0; /* Not set? Nothing to do */
+
+  /* Only AF_UNIX is supported, with path or abstract sockets */
+  if (socket_path[0] != '/' && socket_path[0] != '@')
+    return -EAFNOSUPPORT;
+
+  path_length = strlen(socket_path);
+  /* Ensure there is room for NUL byte */
+  if (path_length >= sizeof(socket_addr.sun.sun_path))
+    return -E2BIG;
+
+  memcpy(socket_addr.sun.sun_path, socket_path, path_length);
+
+  /* Support for abstract socket */
+  if (socket_addr.sun.sun_path[0] == '@')
+    socket_addr.sun.sun_path[0] = 0;
+
+  fd = socket(AF_UNIX, SOCK_DGRAM|SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -errno;
+
+  if (connect(fd, &socket_addr.sa, offsetof(struct sockaddr_un, sun_path) + path_length) != 0)
+    return -errno;
+
+  written = write(fd, message, message_length);
+  if (written != (ssize_t) message_length)
+    return written < 0 ? -errno : -EPROTO;
+
+  return 1; /* Notified! */
+}
+
+static inline int sd_notify(int unset_environment, const char *message) {
+    int r = xen_sd_notify(message);
+
+    if (unset_environment)
+        unsetenv("NOTIFY_SOCKET");
+
+    return r;
+}
+
+#endif /* XEN_SD_NOTIFY */

--- a/oxenstored/systemd/systemd.ml
+++ b/oxenstored/systemd/systemd.ml
@@ -1,0 +1,15 @@
+(*
+ * Copyright (C) 2014 Luis R. Rodriguez <mcgrof@suse.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+external sd_notify_ready : unit -> unit = "ocaml_sd_notify_ready"

--- a/oxenstored/systemd/systemd.mli
+++ b/oxenstored/systemd/systemd.mli
@@ -1,0 +1,16 @@
+(*
+ * Copyright (C) 2014 Luis R. Rodriguez <mcgrof@suse.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+external sd_notify_ready : unit -> unit = "ocaml_sd_notify_ready"
+(** Tells systemd we're ready *)

--- a/oxenstored/systemd/systemd_stubs.c
+++ b/oxenstored/systemd/systemd_stubs.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014 Luis R. Rodriguez <mcgrof@suse.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/signals.h>
+#include <caml/fail.h>
+
+#if defined(HAVE_SYSTEMD)
+
+#include <xen-sd-notify.h>
+
+CAMLprim value ocaml_sd_notify_ready(value ignore)
+{
+	CAMLparam1(ignore);
+
+	sd_notify(1, "READY=1");
+
+	CAMLreturn(Val_unit);
+}
+
+#else
+
+CAMLprim value ocaml_sd_notify_ready(value ignore)
+{
+	CAMLparam1(ignore);
+
+	CAMLreturn(Val_unit);
+}
+#endif

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -710,6 +710,7 @@ let () =
     process_domains store cons domains
   in
 
+  Systemd.sd_notify_ready () ;
   let live_update = ref false in
   while not (!quit && Connections.prevents_quit cons = []) do
     try


### PR DESCRIPTION
This reverts commit 720f5957c0adee87fbe7efd0ef1a319b7a474e94, adapting the contents to the new build system and reformatting them, also bringing in xen-sd-notify.h from upstream.

This fixes the issues I've been seeing with XS9, with the xenstored.service now starting up properly and not timing out without the ready notification.