### PR TITLE
 CP-44717: More optimizations and cleanup

### DIFF
--- a/oxenstored/process.ml
+++ b/oxenstored/process.ml
@@ -85,7 +85,7 @@ let process_watch source t cons =
     Connections.fire_watches ?oldroot source root cons (snd op) recurse
   in
   List.iter (fun op -> do_op_watch op cons) ops ;
-  Connections.send_watchevents cons source
+  Connections.send_watchevents source
 
 let create_implicit_path t perm path =
   let dirname = Store.Path.get_parent path in
@@ -312,7 +312,7 @@ let do_debug con t _domains cons data =
             Printf.sprintf
               "xenbus: %s; overflow queue length: %d, can_input: %b, \
                has_more_input: %b, has_old_output: %b, has_new_output: %b, \
-               has_more_work: %b. pending: %s"
+               has_more_work: %b."
               (Xenbus.Xb.debug con.xb)
               (Connection.source_pending_watchevents con)
               (Connection.can_input con)
@@ -320,7 +320,6 @@ let do_debug con t _domains cons data =
               (Connection.has_old_output con)
               (Connection.has_new_output con)
               (Connection.has_more_work con)
-              (Connections.debug_watchevents cons con)
           in
           Some s
       | "mfn" :: domid :: _ ->


### PR DESCRIPTION
Two more optimizations that were discussed did not make the cut as they actually made performance worse, they're in https://github.com/last-genius/oxenstored/tree/private/asultanov/unneeded-opt for posterity.

Improvements compared to `main` are:
* for 2 threads - 1.3% (p-value of t-test: 0.0075)
* for 4 threads - 3.9% (p-value of t-test: 6.620519373371505e-06)
* for 8 threads - 6.3% (p-value of t-test: 0.00056)
* for 16 threads - 13.5% (p-value of t-test: 1.4654616638726626e-07)

![del_anon_optimizations](https://github.com/user-attachments/assets/0515e07e-feb3-42f2-a804-c7714a614d89)
