### PR TITLE
Implement optional `depth` parameter for watches

### DIFF
--- a/oxenstored/connection.ml
+++ b/oxenstored/connection.ml
@@ -347,10 +347,7 @@ let get_watch_path con path =
     rpath ^ path
 
 let get_watches (con : t) path =
-  if Hashtbl.mem con.watches path then
-    Hashtbl.find con.watches path
-  else
-    []
+  Option.value ~default:[] (Hashtbl.find_opt con.watches path)
 
 let get_children_watches con path =
   let path = path ^ "/" in

--- a/oxenstored/connection.ml
+++ b/oxenstored/connection.ml
@@ -163,30 +163,6 @@ let update_poll_status_on_pop con is_partial_empty poll_status =
   if (not poll_status.Poll.read) && Xenbus.Xb.can_input con.xb then
     poll_status.Poll.read <- true
 
-module Watch = struct
-  module T = struct
-    type t = watch
-
-    let compare w1 w2 =
-      (* cannot compare watches from different connections *)
-      assert (w1.con == w2.con) ;
-      match String.compare w1.token w2.token with
-      | 0 ->
-          String.compare w1.path w2.path
-      | n ->
-          n
-  end
-
-  module Set = Set.Make (T)
-
-  let flush_events t =
-    BoundedPipe.flush_pipe t.pending_watchevents ;
-    Option.iter (update_poll_status_on_push t.con) t.con.poll_status ;
-    not (BoundedPipe.is_empty t.pending_watchevents)
-
-  let pending_watchevents t = BoundedPipe.length t.pending_watchevents
-end
-
 let source_flush_watchevents t =
   BoundedPipe.flush_pipe t.pending_source_watchevents ;
   (* pending_source_watchevents is possibly empty now, check if

--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -174,6 +174,21 @@ let add_watch cons con path token depth =
   let apath = Connection.get_watch_path con path in
   (* fail on invalid paths early by calling key_of_str before adding watch *)
   let key = key_of_str apath in
+  let is_special_watch = apath.[0] = '@' in
+  ( if is_special_watch then
+      (* No depth can be specified for @releaseDomain/domid watches.
+         Only depth=1 can be specified for other special watches *)
+      match depth with
+      | Some _ when String.starts_with ~prefix:"@releaseDomain/" apath ->
+          raise
+            (Invalid_argument
+               "@releaseDomain/domid does not accept a depth parameter"
+            )
+      | Some x when x <> 1 ->
+          raise (Invalid_argument "If set, special watches' depth can only be 1")
+      | _ ->
+          ()
+  ) ;
   let watch = Connection.add_watch con (path, apath) token depth in
   let watches =
     if Trie.mem cons.watches key then
@@ -220,12 +235,36 @@ let fire_watches ?oldroot source root cons path recurse =
 
 let send_watchevents con = Connection.source_flush_watchevents con
 
-let fire_spec_watches root cons specpath =
+let fire_spec_watches root cons specpath domid =
   let source = find_domain cons 0 in
+
+  (* Trigger @releaseDomain/domid watches as well *)
+  let specpaths =
+    specpath
+    ::
+    ( if specpath = "@releaseDomain" then
+        [Printf.sprintf "%s/%d" specpath domid]
+      else
+        []
+    )
+  in
   iter cons (fun con ->
       List.iter
-        (Connection.fire_single_watch source (None, root) 0)
-        (Connection.get_watches con specpath)
+        (fun specpath ->
+          List.iter
+            (fun w ->
+              (* Report the path as '@xDomain/domid' if depth is specified *)
+              let watch =
+                if w.Connection.depth = Some 1 then
+                  {w with path= Printf.sprintf "%s/%d" specpath domid}
+                else
+                  w
+              in
+              Connection.fire_single_watch source (None, root) 0 watch
+            )
+            (Connection.get_watches con specpath)
+        )
+        specpaths
   )
 
 let set_target cons domain target_domain =

--- a/oxenstored/process.ml
+++ b/oxenstored/process.ml
@@ -800,7 +800,7 @@ let do_introduce con t domains cons data =
         let ndom = Domains.create ~remote_port domains domid mfn in
         Connections.add_domain cons ndom ;
         Connections.fire_spec_watches (Transaction.get_root t) cons
-          Store.Path.introduce_domain ;
+          Store.Path.introduce_domain domid ;
         ndom
       with _ -> raise Invalid_Cmd_Args
   in
@@ -823,7 +823,7 @@ let do_release con t domains cons data =
   Store.reset_permissions (Transaction.get_store t) domid ;
   if fire_spec_watches then
     Connections.fire_spec_watches (Transaction.get_root t) cons
-      Store.Path.release_domain
+      Store.Path.release_domain domid
   else
     raise Invalid_Cmd_Args
 

--- a/oxenstored/utils.ml
+++ b/oxenstored/utils.ml
@@ -19,12 +19,14 @@ open Stdext
 
 exception ConversionFailed of string
 
-let int_of_string_exn x =
+let int_of_string_exn ?(unsigned = false) x =
   match int_of_string_opt x with
-  | Some i ->
-      i
+  | Some i when unsigned && i < 0 ->
+      raise (ConversionFailed x)
   | None ->
       raise (ConversionFailed x)
+  | Some i ->
+      i
 
 (* lists utils *)
 let filter_out filter l = List.filter (fun x -> not (List.mem x filter)) l

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -567,9 +567,12 @@ let main () =
             let notify, deaddom = Domains.cleanup domains in
             List.iter (Store.reset_permissions store) deaddom ;
             List.iter (Connections.del_domain cons) deaddom ;
-            if deaddom <> [] || notify then
-              Connections.fire_spec_watches (Store.get_root store) cons
-                Store.Path.release_domain
+            if notify then
+              List.iter
+                (Connections.fire_spec_watches (Store.get_root store) cons
+                   Store.Path.release_domain
+                )
+                deaddom
           ) else
             let c = Connections.find_domain_by_port cons port in
             match Connection.get_domain c with


### PR DESCRIPTION
This new parameter was specified upstream, see: [3a2feae17e0e43ab87565ab58334147fc8443915](https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=3a2feae17e0e43ab87565ab58334147fc8443915)

Additional discussion here: https://lore.kernel.org/xen-devel/aad590a6-fd57-4c8b-bc64-93b7f12a9352@suse.com/

This (coupled with client integration) could help xapi/xenopsd greatly.

Fixes #15 