### PR TITLE
Implement `depth` for special watches, again

### DIFF
--- a/oxenstored/connections.ml
+++ b/oxenstored/connections.ml
@@ -174,6 +174,21 @@ let add_watch cons con path token depth =
   let apath = Connection.get_watch_path con path in
   (* fail on invalid paths early by calling key_of_str before adding watch *)
   let key = key_of_str apath in
+  let is_special_watch = apath.[0] = '@' in
+  ( if is_special_watch then
+      (* No depth can be specified for @releaseDomain/domid watches.
+         Only depth=1 can be specified for other special watches *)
+      match depth with
+      | Some _ when String.starts_with ~prefix:"@releaseDomain/" apath ->
+          raise
+            (Invalid_argument
+               "@releaseDomain/domid does not accept a depth parameter"
+            )
+      | Some x when x <> 1 ->
+          raise (Invalid_argument "If set, special watches' depth can only be 1")
+      | _ ->
+          ()
+  ) ;
   let watch = Connection.add_watch con (path, apath) token depth in
   let watches =
     if Trie.mem cons.watches key then
@@ -220,12 +235,36 @@ let fire_watches ?oldroot source root cons path recurse =
 
 let send_watchevents con = Connection.source_flush_watchevents con
 
-let fire_spec_watches root cons specpath =
+let fire_spec_watches root cons specpath domid =
   let source = find_domain cons 0 in
+
+  (* Trigger @releaseDomain/domid watches as well *)
+  let specpaths =
+    specpath
+    ::
+    ( if specpath = "@releaseDomain" then
+        [Printf.sprintf "%s/%d" specpath domid]
+      else
+        []
+    )
+  in
   iter cons (fun con ->
       List.iter
-        (Connection.fire_single_watch source (None, root) 0)
-        (Connection.get_watches con specpath)
+        (fun specpath ->
+          List.iter
+            (fun w ->
+              (* Report the path as '@xDomain/domid' if depth is specified *)
+              let watch =
+                if w.Connection.depth = Some 1 then
+                  {w with path= Printf.sprintf "%s/%d" specpath domid}
+                else
+                  w
+              in
+              Connection.fire_single_watch source (None, root) 0 watch
+            )
+            (Connection.get_watches con specpath)
+        )
+        specpaths
   )
 
 let set_target cons domain target_domain =

--- a/oxenstored/domains.ml
+++ b/oxenstored/domains.ml
@@ -131,8 +131,8 @@ let remove_from_queue dom queue =
     queue
 
 let cleanup doms =
-  let notify = ref false in
-  let dead_dom = ref [] in
+  let shutdown_domains = ref [] in
+  let dead_domains = ref [] in
 
   Hashtbl.iter
     (fun id _ ->
@@ -143,13 +143,13 @@ let cleanup doms =
             debug "Domain %u died (dying=%b, shutdown %b -- code %d)" id
               info.Plugin.dying info.Plugin.shutdown info.Plugin.shutdown_code ;
             if info.Plugin.dying then
-              dead_dom := id :: !dead_dom
+              dead_domains := id :: !dead_domains
             else
-              notify := true
+              shutdown_domains := id :: !shutdown_domains
           )
         with Plugin.Error _ ->
           debug "Domain %u died -- no domain info" id ;
-          dead_dom := id :: !dead_dom
+          dead_domains := id :: !dead_domains
       )
     )
     doms.table ;
@@ -164,8 +164,8 @@ let cleanup doms =
           remove_from_queue dom doms.doms_conflict_paused
       )
     )
-    !dead_dom ;
-  (!notify, !dead_dom)
+    !dead_domains ;
+  (!shutdown_domains, !dead_domains)
 
 let resume _doms _domid = ()
 

--- a/oxenstored/process.ml
+++ b/oxenstored/process.ml
@@ -800,7 +800,7 @@ let do_introduce con t domains cons data =
         let ndom = Domains.create ~remote_port domains domid mfn in
         Connections.add_domain cons ndom ;
         Connections.fire_spec_watches (Transaction.get_root t) cons
-          Store.Path.introduce_domain ;
+          Store.Path.introduce_domain domid ;
         ndom
       with _ -> raise Invalid_Cmd_Args
   in
@@ -823,7 +823,7 @@ let do_release con t domains cons data =
   Store.reset_permissions (Transaction.get_store t) domid ;
   if fire_spec_watches then
     Connections.fire_spec_watches (Transaction.get_root t) cons
-      Store.Path.release_domain
+      Store.Path.release_domain domid
   else
     raise Invalid_Cmd_Args
 

--- a/oxenstored/process.ml
+++ b/oxenstored/process.ml
@@ -800,7 +800,7 @@ let do_introduce con t domains cons data =
         let ndom = Domains.create ~remote_port domains domid mfn in
         Connections.add_domain cons ndom ;
         Connections.fire_spec_watches (Transaction.get_root t) cons
-          Store.Path.introduce_domain domid ;
+          Store.Path.introduce_domain [domid] ;
         ndom
       with _ -> raise Invalid_Cmd_Args
   in
@@ -823,7 +823,7 @@ let do_release con t domains cons data =
   Store.reset_permissions (Transaction.get_store t) domid ;
   if fire_spec_watches then
     Connections.fire_spec_watches (Transaction.get_root t) cons
-      Store.Path.release_domain domid
+      Store.Path.release_domain [domid]
   else
     raise Invalid_Cmd_Args
 

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -565,15 +565,14 @@ let main () =
       finally
         (fun () ->
           if port = eventchn.Event.domexc then (
-            let notify, deaddom = Domains.cleanup domains in
-            List.iter (Store.reset_permissions store) deaddom ;
-            List.iter (Connections.del_domain cons) deaddom ;
-            if notify then
-              List.iter
-                (Connections.fire_spec_watches (Store.get_root store) cons
-                   Store.Path.release_domain
-                )
-                deaddom
+            let shutdown_domains, dead_domains = Domains.cleanup domains in
+            List.iter (Store.reset_permissions store) dead_domains ;
+            List.iter (Connections.del_domain cons) dead_domains ;
+            List.iter
+              (Connections.fire_spec_watches (Store.get_root store) cons
+                 Store.Path.release_domain
+              )
+              (List.append dead_domains shutdown_domains)
           ) else
             let c = Connections.find_domain_by_port cons port in
             match Connection.get_domain c with

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -567,9 +567,12 @@ let main () =
             let notify, deaddom = Domains.cleanup domains in
             List.iter (Store.reset_permissions store) deaddom ;
             List.iter (Connections.del_domain cons) deaddom ;
-            if deaddom <> [] || notify then
-              Connections.fire_spec_watches (Store.get_root store) cons
-                Store.Path.release_domain
+            if notify then
+              List.iter
+                (Connections.fire_spec_watches (Store.get_root store) cons
+                   Store.Path.release_domain
+                )
+                deaddom
           ) else
             let c = Connections.find_domain_by_port cons port in
             match Connection.get_domain c with

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -438,7 +438,8 @@ let main () =
         (Unix.handle_unix_error Utils.create_unix_socket Define.xs_daemon_socket)
   in
 
-  if cf.daemonize && not cf.live_reload then
+  if (not Testing_status.under_testing) && cf.daemonize && not cf.live_reload
+  then
     Unixext.daemonize ()
   else
     printf "Xen Storage Daemon, version %d.%d\n%!" Define.xenstored_major
@@ -718,45 +719,50 @@ let main () =
 
     if cfds <> [] || wset <> [] then
       process_connection_fds store cons domains cfds wset spec_fds ;
-    ( if timeout <> 0. then
-        let now = Unix.gettimeofday () in
-        if now > !period_start +. period_ops_interval then (
-          period_start := now ;
-          periodic_ops now
-        )
-    ) ;
+    if not Testing_status.under_testing then (
+      ( if timeout <> 0. then
+          let now = Unix.gettimeofday () in
+          if now > !period_start +. period_ops_interval then (
+            period_start := now ;
+            periodic_ops now
+          )
+      ) ;
 
-    process_domains store cons domains
+      process_domains store cons domains
+    )
   in
 
-  Systemd.sd_notify_ready () ;
-  let live_update = ref false in
-  while not (!quit && Connections.prevents_quit cons = []) do
-    try
-      main_loop () ;
-      live_update := Process.LiveUpdate.should_run cons ;
-      if !live_update || !quit then (
-        (* don't initiate live update if saving state fails *)
-        DB.to_file store cons (rw_sock, eventchn) Disk.xs_daemon_database ;
-        quit := true
-      )
-    with exc ->
-      let bt = Printexc.get_backtrace () in
-      error "caught exception %s: %s" (Printexc.to_string exc) bt ;
-      if cf.reraise_top_level then
-        raise exc
-  done ;
-  info "stopping xenstored" ;
-  (* unlink pidfile so that launch-xenstore works again *)
-  Unixext.unlink_safe pidfile ;
-  ( match cf.pidfile with
-  | Some pidfile ->
-      Unixext.unlink_safe pidfile
-  | None ->
-      ()
-  ) ;
+  if not Testing_status.under_testing then (
+    Systemd.sd_notify_ready () ;
+    let live_update = ref false in
+    while not (!quit && Connections.prevents_quit cons = []) do
+      try
+        main_loop () ;
+        live_update := Process.LiveUpdate.should_run cons ;
+        if !live_update || !quit then (
+          (* don't initiate live update if saving state fails *)
+          DB.to_file store cons (rw_sock, eventchn) Disk.xs_daemon_database ;
+          quit := true
+        )
+      with exc ->
+        let bt = Printexc.get_backtrace () in
+        error "caught exception %s: %s" (Printexc.to_string exc) bt ;
+        if cf.reraise_top_level then
+          raise exc
+    done ;
+    info "stopping xenstored" ;
+    (* unlink pidfile so that launch-xenstore works again *)
+    Unixext.unlink_safe pidfile ;
+    ( match cf.pidfile with
+    | Some pidfile ->
+        Unixext.unlink_safe pidfile
+    | None ->
+        ()
+    ) ;
 
-  if !live_update then (
-    Logging.live_update () ;
-    Process.LiveUpdate.launch_exn !Process.LiveUpdate.state
-  )
+    if !live_update then (
+      Logging.live_update () ;
+      Process.LiveUpdate.launch_exn !Process.LiveUpdate.state
+    )
+  ) ;
+  (main_loop, store, cons, domains)

--- a/oxenstored/xenstored.ml
+++ b/oxenstored/xenstored.ml
@@ -568,10 +568,8 @@ let main () =
             let shutdown_domains, dead_domains = Domains.cleanup domains in
             List.iter (Store.reset_permissions store) dead_domains ;
             List.iter (Connections.del_domain cons) dead_domains ;
-            List.iter
-              (Connections.fire_spec_watches (Store.get_root store) cons
-                 Store.Path.release_domain
-              )
+            Connections.fire_spec_watches (Store.get_root store) cons
+              Store.Path.release_domain
               (List.append dead_domains shutdown_domains)
           ) else
             let c = Connections.find_domain_by_port cons port in

--- a/oxenstored/xenstored_main.ml
+++ b/oxenstored/xenstored_main.ml
@@ -1,1 +1,2 @@
-let () = Xenstored.main ()
+let _ : (unit -> unit) * Store.t * Connections.t * Domains.domains =
+  Xenstored.main ()

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,4 @@
-(copy_files# ../oxenstored/*.ml{,i})
+(copy_files# (only_sources true) (files ../oxenstored/*.ml{,i}))
 (copy_files# ../ocaml-evtchn/lib/eventchn_stubs.c)
 
 (library

--- a/tests/paths.ml
+++ b/tests/paths.ml
@@ -1,0 +1,9 @@
+let xen_log_dir = "/tmp"
+
+let xen_config_dir = "/tmp"
+
+let xen_run_dir = "/tmp"
+
+let xen_run_stored = "/tmp"
+
+let libexec = "/tmp"

--- a/tests/plugin_interface_v1.ml
+++ b/tests/plugin_interface_v1.ml
@@ -38,7 +38,13 @@ module Domain_getinfo_V1_impl = struct
   let interface_open () = 1
 
   let domain_getinfo _h domid =
-    {domid; dying= false; shutdown= false; shutdown_code= 1}
+    (* Special casing for test_introduce_release_watches_on_domain_death *)
+    if domid > 2000 then
+      {domid; dying= true; shutdown= false; shutdown_code= 1}
+    else if domid > 1000 then
+      {domid; dying= false; shutdown= true; shutdown_code= 1}
+    else
+      {domid; dying= false; shutdown= false; shutdown_code= 1}
 
   let domain_getinfolist _h =
     [|{domid= 1; dying= false; shutdown= false; shutdown_code= 1}|]

--- a/tests/unix_activations_minimal.ml
+++ b/tests/unix_activations_minimal.ml
@@ -1,3 +1,3 @@
 let fd _handle = Eventchn.devnull
 
-let pending _handle = 0
+let pending _handle = 1


### PR DESCRIPTION
First commit is just https://github.com/xapi-project/oxenstored/commit/5e559b44d6f247a5781122d2c19a1621bf2a0441, the second one fixes an issue that made oxenstored not fire watch events on domains shutting down. The last commit avoids sending multiple `@releaseDomain` events when several domains die at the same time.

Best reviewed with "hide whitespace".

This passed BVT (Thanks @robhoes!)