### PR TITLE
tools/oxenstored: Reset quota when resetting permissions

### DIFF
--- a/oxenstored/store.ml
+++ b/oxenstored/store.ml
@@ -510,7 +510,8 @@ let reset_permissions store domid =
                 (Node.get_name node) ;
             Some {node with Node.perms}
       )
-      store.root
+      store.root ;
+  store.quota <- Quota.del store.quota domid
 
 type ops = {
     store: t


### PR DESCRIPTION
The quota object contains both limits and the current node usage counts.

When a domain is torn down, the node data itself is cleaned up but the node usage counts are not.  A later domain reusing the same domid can create fewer nodes before being deemed to be over quota.

Reset the count when the node permissions are cleaned up.

This is XSA-483 / CVE-2026-23556.